### PR TITLE
fix: add null check for message to prevent toLowerCase error

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -36,11 +36,22 @@ export async function POST(request: NextRequest) {
     console.log('🧠 Message content:', message);
     console.log('🧠 User ID:', actualUserId);
 
+    // Validate that we have a message
+    if (!message || typeof message !== 'string') {
+      console.log('❌ Invalid or missing message:', message);
+      return NextResponse.json({
+        message: "I didn't receive a valid message. Please try again.",
+        error: true
+      });
+    }
+
     // Check if this is a simple confirmation response
-    const isSimpleConfirmation = message.toLowerCase().trim() === 'yes' || 
-                                message.toLowerCase().trim() === 'y' ||
-                                message.toLowerCase().trim() === 'confirm' ||
-                                message.toLowerCase().trim() === 'correct';
+    const isSimpleConfirmation = message && (
+      message.toLowerCase().trim() === 'yes' || 
+      message.toLowerCase().trim() === 'y' ||
+      message.toLowerCase().trim() === 'confirm' ||
+      message.toLowerCase().trim() === 'correct'
+    );
 
     if (isSimpleConfirmation) {
       console.log('🎯 Simple confirmation detected:', message);


### PR DESCRIPTION
- Add validation to ensure message exists and is a string
- Add null check before calling toLowerCase() on message
- Return error response for invalid messages
- Prevent 500 errors that were breaking table loading