### PR TITLE
feat: add comprehensive debugging for count query issues

### DIFF
--- a/src/lib/conversationalHandler.ts
+++ b/src/lib/conversationalHandler.ts
@@ -203,12 +203,16 @@ export class ConversationalHandler {
       // Skip edge cache for count queries to ensure fresh data
       const isCountQuery = message.toLowerCase().includes('how many') || message.toLowerCase().includes('count');
       
+      console.log('🔍 Count query check:', { message, isCountQuery });
+      
       if (!isCountQuery) {
         const edgeResult = EdgeCache.get(message);
         if (edgeResult) {
           logger.info('Edge cache hit', { action: edgeResult.action, confidence: edgeResult.confidence });
           return await this.executeAction(edgeResult, conversationManager, context);
         }
+      } else {
+        console.log('🔍 Skipping edge cache for count query');
       }
 
       // 2. Try structured analysis (reliable and fast)
@@ -256,7 +260,14 @@ export class ConversationalHandler {
     conversationManager: ConversationManager
   ): Promise<ConversationalUnderstanding | null> {
     try {
+      console.log('🔍 Starting structured analysis for:', message);
       const intent = await intentClassifier.classifyIntent(message, conversationManager.getState());
+      
+      console.log('🔍 Structured analysis result:', {
+        action: intent.action,
+        dataType: intent.entities.dataType,
+        confidence: intent.confidence
+      });
       
       return {
         action: intent.action,
@@ -463,6 +474,8 @@ Analyze this user message and extract structured information for CRM actions.
           clarificationQuestion: understanding.clarificationQuestion
         }
       };
+      
+      console.log('🚀 Structured intent:', structuredIntent);
 
       // Use existing intent router with timeout
       const response = await this.withTimeout(


### PR DESCRIPTION
- Add debugging to count query detection logic
- Add debugging to structured analysis process
- Add debugging to action execution process
- Add logging for edge cache skip decisions
- Add logging for intent classification results
- Add logging for structured intent creation

This will help identify exactly where the count query is failing and why it's returning 5 contacts instead of 4. The debugging will show the complete flow from message to response.